### PR TITLE
fix: 修复用户设置页面提交时的错误处理和类型定义

### DIFF
--- a/ui/src/pages/README.md
+++ b/ui/src/pages/README.md
@@ -1,0 +1,69 @@
+# 用户设置页面（UserSettings）
+
+## 功能说明
+用户设置页面允许用户修改界面语言和主题等个人偏好设置。
+
+### 最新更新
+- 修复了设置提交时的错误处理
+- 增强了表单验证
+- 优化了类型定义
+
+## 主要功能
+
+### 1. 语言设置
+- 支持多语言切换
+- 实时预览语言更改
+- 完善的错误提示
+
+### 2. 错误处理优化
+- 添加了表单提交验证
+- 显示详细的错误信息
+- 支持网络错误提示
+
+## 使用说明
+
+### 修改界面语言
+1. 从下拉菜单选择目标语言
+2. 点击"提交"保存更改
+3. 成功后会显示确认消息
+
+### 错误情况处理
+- 未选择语言：显示必选提示
+- 网络错误：显示具体错误信息
+- 提交成功：显示成功提示
+
+## 技术实现
+- 使用 React 18+ 
+- AWS Amplify GraphQL API
+- Cloudscape Design Components
+- TypeScript 类型安全
+
+## 代码示例
+```typescript
+// 语言更新逻辑
+const handleLanguageSubmit = (e: React.FormEvent) => {
+  e.preventDefault();
+  
+  if (!uiLang?.value) {
+    dispatchAlert({ 
+      type: AlertType.ERROR, 
+      content: getText('common.settings.language_required') 
+    });
+    return;
+  }
+
+  client.graphql<any>({
+    mutation: upsertSettings,
+    variables: { 
+      input: { 
+        uiLang: uiLang.value as Lang
+      } 
+    },
+  })
+};
+```
+
+## 后续优化计划
+1. 添加语言切换的过渡动画
+2. 增加更多个性化设置选项
+3. 优化错误提示的用户体验

--- a/ui/src/pages/UserSettings.tsx
+++ b/ui/src/pages/UserSettings.tsx
@@ -30,21 +30,46 @@ export default () => {
     });
   }, []);
 
+  interface GraphQLError {
+    message: string;
+    // 其他可能的错误字段
+  }
+
   const handleLanguageSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    
+    // 检查语言选择是否有效
+    if (!uiLang?.value) {
+      dispatchAlert({ 
+        type: AlertType.ERROR, 
+        content: getText('common.settings.language_required') 
+      });
+      return;
+    }
+
     client
       .graphql<any>({
-        query: upsertSettings,
+        mutation: upsertSettings,  // 使用 mutation 而不是 query
         variables: { 
           input: { 
-            uiLang: uiLang?.value as Lang
+            uiLang: uiLang.value as Lang  // 已经检查过 value 存在，可以安全使用
           } 
         },
       })
-      .then(() => dispatchAlert({ type: AlertType.SUCCESS, content: getText('common.settings.update_success') }))
-      .catch((error) => {
+      .then(() => {
+        dispatchAlert({ 
+          type: AlertType.SUCCESS, 
+          content: getText('common.settings.update_success') 
+        });
+      })
+      .catch((error: GraphQLError) => {
         console.error('Settings update error:', error);
-        dispatchAlert({ type: AlertType.ERROR, content: getText('common.status.error') });
+        // 显示更具体的错误信息
+        const errorMessage = error.message || getText('common.status.error');
+        dispatchAlert({ 
+          type: AlertType.ERROR, 
+          content: errorMessage 
+        });
       });
   };
 


### PR DESCRIPTION
## 修改内容

1. 修复了 GraphQL mutation 的语法错误
   - 将 `query` 改为 `mutation`，因为 `upsertSettings` 是一个更新操作

2. 增强了错误处理
   - 添加了 `GraphQLError` 接口定义
   - 在 catch 块中显示具体的错误信息
   - 使用 error.message 作为首选错误提示

3. 改进了表单验证
   - 添加了语言选择的空值检查
   - 在提交前验证 uiLang 值是否有效
   
4. 优化了代码结构
   - 添加了详细的注释
   - 改进了代码格式化
   - 类型安全性增强

## 测试说明

请测试以下场景：
1. 正常选择语言并提交
2. 不选择语言直接提交
3. 网络错误或后端报错时的提示